### PR TITLE
use github.repository_owner in IMAGE_NAME in docker build workflows

### DIFF
--- a/.github/workflows/docker-build-genesis-deployer.yml
+++ b/.github/workflows/docker-build-genesis-deployer.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: planetarium/mothership-l2launcher-genesis-deployer
+  IMAGE_NAME: ${{ github.repository_owner }}/mothership-l2launcher-genesis-deployer
 
 jobs:
   build:

--- a/.github/workflows/docker-build-genesis-deployer.yml
+++ b/.github/workflows/docker-build-genesis-deployer.yml
@@ -21,14 +21,14 @@ jobs:
 
     steps:
       - name: Install cosign
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.repository_owner == 'planetarium'
         uses: sigstore/cosign-installer@v3.1.1
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.0.0
 
       - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.repository_owner == 'planetarium'
         uses: docker/login-action@v3.0.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -52,14 +52,14 @@ jobs:
         with:
           context: "{{defaultContext}}:genesis-deployer"
           platforms: linux/amd64,linux/arm64/v8
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' && github.repository_owner == 'planetarium' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Sign the published Docker image
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ github.event_name != 'pull_request' && github.repository_owner == 'planetarium' }}
         run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}
         env:
           TAGS: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker-build-genesis-init-predeploy.yml
+++ b/.github/workflows/docker-build-genesis-init-predeploy.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: planetarium/mothership-l2launcher-genesis-init-predeploy
+  IMAGE_NAME: ${{ github.repository_owner }}/mothership-l2launcher-genesis-init-predeploy
 
 jobs:
   build:

--- a/.github/workflows/docker-build-genesis-init-predeploy.yml
+++ b/.github/workflows/docker-build-genesis-init-predeploy.yml
@@ -21,14 +21,14 @@ jobs:
 
     steps:
       - name: Install cosign
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.repository_owner == 'planetarium'
         uses: sigstore/cosign-installer@v3.1.1
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.0.0
 
       - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.repository_owner == 'planetarium'
         uses: docker/login-action@v3.0.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -52,14 +52,14 @@ jobs:
         with:
           context: "{{defaultContext}}:genesis-init-predeploy"
           platforms: linux/amd64,linux/arm64/v8
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' && github.repository_owner == 'planetarium' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Sign the published Docker image
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ github.event_name != 'pull_request' && github.repository_owner == 'planetarium' }}
         run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}
         env:
           TAGS: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
This would fix broken docker build workflows in github actions for forked repositories