### PR TITLE
add proxyd, upgrade optimism to v1.7.7, change op-geth registry

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -112,6 +112,9 @@ await Deno.writeTextFile("out/predeploy.json", await fetchTemplate("templates/pr
 await Deno.writeTextFile("out/docker-compose.yml", dockerComposeYml);
 console.log("out/docker-compose.yml copied.");
 
+await Deno.writeTextFile("out/proxyd.toml", await fetchTemplate("templates/proxyd.toml"));
+console.log("out/proxyd.toml copied.");
+
 const dotenv = Object.entries(env)
   .filter(([k]) => envKeys.includes(k as typeof envKeys[number]))
   .map(([k, v]) => `${k}=${v}`)

--- a/genesis-init-predeploy/Dockerfile
+++ b/genesis-init-predeploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/planetarium/op-geth:latest as op-geth
+FROM stackupwallet/op-geth:v1.101315.2 as op-geth
 
 FROM buildpack-deps:scm as foundry
 ARG TARGETARCH

--- a/genesis-init-predeploy/Dockerfile
+++ b/genesis-init-predeploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM stackupwallet/op-geth:v1.101315.2 as op-geth
+FROM ghcr.io/planetarium/op-geth:v1.101315.2 as op-geth
 
 FROM buildpack-deps:scm as foundry
 ARG TARGETARCH

--- a/templates/docker-compose-blockscout.yml
+++ b/templates/docker-compose-blockscout.yml
@@ -7,6 +7,7 @@
       - blockscout-smart-contract-verifier
       - blockscout-visualizer
       - op-geth
+      - proxyd
     volumes:
       - ./data/blockscout/logs/:/app/logs/
       - ./data/genesis:/genesis:ro
@@ -19,8 +20,8 @@
       SUBNETWORK: L2 CHAIN ${L2_CHAIN_ID}
       # LOGO: /images/blockscout_logo.svg
       ETHEREUM_JSONRPC_VARIANT: geth
-      ETHEREUM_JSONRPC_HTTP_URL: http://op-geth:8545/
-      ETHEREUM_JSONRPC_TRACE_URL: http://op-geth:8545/
+      ETHEREUM_JSONRPC_HTTP_URL: http://proxyd:8080/
+      ETHEREUM_JSONRPC_TRACE_URL: http://proxyd:8080/
       DATABASE_URL: postgresql://postgres:@blockscout-postgres:5432/blockscout?ssl=false
       # ETHEREUM_JSONRPC_TRANSPORT: http
       # ETHEREUM_JSONRPC_DISABLE_ARCHIVE_BALANCES: false

--- a/templates/docker-compose-bundler.yml
+++ b/templates/docker-compose-bundler.yml
@@ -1,6 +1,6 @@
   stackup-bundler:
     container_name: stackup-bundler
-    image: stackupwallet/stackup-bundler:latest
+    image: stackupwallet/stackup-bundler:v0.6.47
     ports:
       - 4337:4337/tcp
     depends_on:

--- a/templates/docker-compose-bundler.yml
+++ b/templates/docker-compose-bundler.yml
@@ -6,8 +6,10 @@
     depends_on:
       op-geth:
         condition: service_healthy
+      proxyd:
+        condition: service_started
     environment:
-      ERC4337_BUNDLER_ETH_CLIENT_URL: http://op-geth:8545
+      ERC4337_BUNDLER_ETH_CLIENT_URL: http://proxyd:8080
       ERC4337_BUNDLER_SUPPORTED_ENTRY_POINTS: ${ERC4337_ENTRYPOINT:-0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789}
       ERC4337_BUNDLER_PRIVATE_KEY: ${ERC4337_BUNDLER_KEY}
       ERC4337_BUNDLER_NATIVE_BUNDLER_COLLECTOR_TRACER: bundlerCollectorTracer

--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -27,7 +27,7 @@ services:
 
   op-geth:
     container_name: op-geth
-    image: stackupwallet/op-geth:v1.101315.2
+    image: ghcr.io/planetarium/op-geth:v1.101315.2
     volumes:
       - ./data/op-geth:/data
       - ./data/genesis:/genesis

--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -27,7 +27,7 @@ services:
 
   op-geth:
     container_name: op-geth
-    image: ghcr.io/planetarium/op-geth:latest
+    image: stackupwallet/op-geth:v1.101315.2
     volumes:
       - ./data/op-geth:/data
       - ./data/genesis:/genesis
@@ -65,7 +65,7 @@ services:
 
   op-node:
     container_name: op-node
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.7.5
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.7.7
     volumes:
       - ./data/op-node:/data
       - ./data/genesis:/genesis    
@@ -98,7 +98,7 @@ services:
 
   op-batcher:
     container_name: op-batcher
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-batcher:v1.7.4
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-batcher:v1.7.7
     depends_on:
       op-node:
         condition: service_healthy
@@ -124,7 +124,7 @@ services:
 
   op-proposer:
     container_name: op-proposer
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-proposer:v1.7.4
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-proposer:v1.7.7
     volumes:
       - ./data/genesis:/genesis
     depends_on:
@@ -140,3 +140,14 @@ services:
           --l2oo-address=$$(cat /genesis/L2OutputOracleProxyAddress) \
           --private-key=${PROPOSER_KEY} \
           --l1-eth-rpc=${L1_RPC}
+
+  proxyd:
+    container_name: proxyd
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/proxyd:v4.6.0
+    depends_on:
+      op-geth:
+        condition: service_healthy
+    volumes:
+      - ./proxyd.toml:/etc/proxyd/proxyd.toml
+    ports:
+      - 8080:8080

--- a/templates/proxyd.toml
+++ b/templates/proxyd.toml
@@ -1,0 +1,82 @@
+ws_method_whitelist = [
+  "eth_subscribe",
+  "eth_call",
+  "eth_chainId"
+]
+ws_backend_group = "main"
+
+[server]
+rpc_host = "0.0.0.0"
+rpc_port = 8080
+ws_host = "0.0.0.0"
+ws_port = 8085
+max_body_size_bytes = 10485760
+max_concurrent_rpcs = 1000
+log_level = "info"
+
+[backend]
+response_timeout_seconds = 5
+max_response_size_bytes = 5242880
+max_retries = 3
+out_of_service_seconds = 600
+max_latency_threshold = "30s"
+max_degraded_latency_threshold = "10s"
+max_error_rate_threshold = 0.3
+
+[backends]
+[backends.geth]
+rpc_url = "http://op-geth:8545"
+ws_url = "http://op-geth:8546"
+max_rps = 3
+max_ws_conns = 1
+consensus_receipts_target = "eth_getBlockReceipts"
+
+[backend_groups]
+[backend_groups.main]
+backends = ["geth"]
+consensus_aware = false
+
+[backend_groups.sequencer]
+backends = ["geth"]
+
+[rpc_method_mappings]
+web3_clientVersion = "main"
+web3_sha3 = "main"
+net_version = "main"
+net_peerCount = "main"
+net_listening = "main"
+eth_blockNumber = "main"
+eth_call = "main"
+eth_getBalance = "main"
+eth_getStorageAt = "main"
+eth_getTransactionCount = "main"
+eth_getBlockTransactionCountByHash = "main"
+eth_getBlockTransactionCountByNumber = "main"
+eth_getUncleCountByBlockHash = "main"
+eth_getUncleCountByBlockNumber = "main"
+eth_getCode = "main"
+eth_sendRawTransaction = "main"
+eth_getBlockByHash = "main"
+eth_getBlockByNumber = "main"
+eth_getTransactionByHash = "main"
+eth_getTransactionByBlockHashAndIndex = "main"
+eth_getTransactionByBlockNumberAndIndex = "main"
+eth_getUncleByBlockHashAndIndex = "main"
+eth_getUncleByBlockNumberAndIndex = "main"
+eth_newFilter = "main"
+eth_newBlockFilter = "main"
+eth_newPendingTransactionFilter = "main"
+eth_uninstallFilter = "main"
+eth_getFilterChanges = "main"
+eth_getFilterLogs = "main"
+eth_getLogs = "main"
+eth_estimateGas = "main"
+eth_gasPrice = "main"
+eth_protocolVersion = "main"
+eth_syncing = "main"
+eth_coinbase = "main"
+eth_mining = "main"
+eth_hashrate = "main"
+eth_chainId = "main"
+eth_getBlockReceipts = "sequencer"
+eth_getTransactionReceipt = "sequencer"

--- a/templates/proxyd.toml
+++ b/templates/proxyd.toml
@@ -24,20 +24,23 @@ max_degraded_latency_threshold = "10s"
 max_error_rate_threshold = 0.3
 
 [backends]
-[backends.geth]
+[backends.node-1]
 rpc_url = "http://op-geth:8545"
-ws_url = "http://op-geth:8546"
-max_rps = 3
-max_ws_conns = 1
+max_rps = 0
+consensus_receipts_target = "eth_getBlockReceipts"
+
+[backends.node-2]
+rpc_url = "http://op-geth:8545"
+max_rps = 0
 consensus_receipts_target = "eth_getBlockReceipts"
 
 [backend_groups]
 [backend_groups.main]
-backends = ["geth"]
+backends = ["node-2", "node-1"]
 consensus_aware = false
 
 [backend_groups.sequencer]
-backends = ["geth"]
+backends = ["node-1"]
 
 [rpc_method_mappings]
 web3_clientVersion = "main"
@@ -55,10 +58,8 @@ eth_getBlockTransactionCountByNumber = "main"
 eth_getUncleCountByBlockHash = "main"
 eth_getUncleCountByBlockNumber = "main"
 eth_getCode = "main"
-eth_sendRawTransaction = "main"
 eth_getBlockByHash = "main"
 eth_getBlockByNumber = "main"
-eth_getTransactionByHash = "main"
 eth_getTransactionByBlockHashAndIndex = "main"
 eth_getTransactionByBlockNumberAndIndex = "main"
 eth_getUncleByBlockHashAndIndex = "main"
@@ -72,11 +73,18 @@ eth_getFilterLogs = "main"
 eth_getLogs = "main"
 eth_estimateGas = "main"
 eth_gasPrice = "main"
+eth_maxPriorityFeePerGas = "main"
 eth_protocolVersion = "main"
 eth_syncing = "main"
 eth_coinbase = "main"
 eth_mining = "main"
 eth_hashrate = "main"
 eth_chainId = "main"
-eth_getBlockReceipts = "sequencer"
+eth_getBlockReceipts = "main"
+debug_traceCall = "main"
+debug_traceTransaction = "main"
+txpool_content = "sequencer"
+eth_sendTransaction = "sequencer"
+eth_sendRawTransaction = "sequencer"
 eth_getTransactionReceipt = "sequencer"
+eth_getTransactionByHash = "sequencer"


### PR DESCRIPTION
- the proxyd has been added to distinguish endpoints for specific RPC calls (especially `eth_getTransactionReceipt`) and to enable load balancing.
- update optimism version to `v1.7.7`
- change op-geth registry to `stackupwallet/op-geth`